### PR TITLE
Improve scrollToItem behaviour when item is below scroll pane mask

### DIFF
--- a/src/megalist.js
+++ b/src/megalist.js
@@ -685,22 +685,22 @@
             return false;
         }
 
-        var shouldScroll = false;
+        var scrollToY = -1;
         var itemOffsetTop = Math.floor(elementIndex / this._calculated['itemsPerRow']) * this.options.itemHeight;
         var itemOffsetTopPlusHeight = itemOffsetTop + this.options.itemHeight;
 
         // check if the item is above the visible viewport
         if (itemOffsetTop < this._calculated['scrollTop']) {
-            shouldScroll = true;
+            scrollToY = itemOffsetTop;
         }
         // check if the item is below the visible viewport
         else if (itemOffsetTopPlusHeight > (this._calculated['scrollTop'] + this._calculated['scrollHeight'])) {
-            shouldScroll = true;
+            scrollToY = itemOffsetTopPlusHeight - this._calculated['scrollHeight'];
         }
 
         // have to scroll
-        if (shouldScroll) {
-            this.listContainer.scrollTop = itemOffsetTop;
+        if (scrollToY !== -1) {
+            this.listContainer.scrollTop = scrollToY;
             this._isUserScroll = false;
             this.scrollUpdate();
             this._onScroll();

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -248,4 +248,61 @@ describe("Basic test", function() {
         expect($('.container .item[data-id="' + firstId + '"]').size()).to.eql(1);
         expect($('.container .item[data-id="' + firstId + '"]').text()).to.eql("Item #1, 321");
     });
+
+    it('list navigation', function() {
+        $($container).css({
+            'width': 320,
+            'height': 320
+        });
+
+        var megaList = new MegaList($container, {
+            itemWidth: 320,
+            itemHeight: 20,
+            itemRenderFunction: Fixtures.DOM.itemDOMNodeGeneratorCallback
+        });
+        // nominal 16 items in list
+
+        Fixtures.randomItemIds(megaList, 100);
+
+        // render
+        megaList.initialRender();
+
+        megaList.scrollToItem(80);
+        expect($('.container .item').last().data('id')).to.eql(80);
+
+        megaList.scrollToItem(20);
+        expect($('.container .item').first().data('id')).to.eql(20);
+
+        megaList.scrollToItem(25);
+        expect($('.container .item[data-id=25]').index()).to.eql(5);
+    });
+
+    it('grid navigation', function() {
+        $($container).css({
+            'width': 320,
+            'height': 320
+        });
+
+        var megaList = new MegaList($container, {
+            itemWidth: 80,
+            itemHeight: 80,
+            itemRenderFunction: Fixtures.DOM.itemDOMNodeGeneratorCallback
+        });
+        // nominal 4x4 grid
+
+        Fixtures.randomItemIds(megaList, 4*4*5);
+        // five pages-worth, 20 rows
+
+        // render
+        megaList.initialRender();
+
+        megaList.scrollToItem(4*14+3); // 15th row, 3rd element in row
+        expect($('.container .item').last().data('id')).to.eql(4*14+4);
+
+        megaList.scrollToItem(4*4+1); // 5th row, 1st element in row
+        expect($('.container .item').first().data('id')).to.eql(4*4+1);
+
+        megaList.scrollToItem(4*5+4); // 6th row, 4th element in row
+        expect($('.container .item[data-id=25]').index()).to.eql(8);
+    });
 });


### PR DESCRIPTION
- If the item passed to scrollToItem is below the scroll pane's mask, then it will scroll such that the item is now the last visible entry.
This opposes the previous behaviour where the item would always be scrolled to be the first visible entry when it is out of view.
- Adds tests navigation list, navigation grid to test this behaviour.